### PR TITLE
Fix undefined symbols and segmentation fault.

### DIFF
--- a/lily_server.c
+++ b/lily_server.c
@@ -177,7 +177,7 @@ var env: Hash[String, Tainted[String]]
 
 This contains key+value pairs containing the current environment of the server.
 */
-static void *load_var_env(lily_state *s)
+void lily_server_var_env(lily_state *s)
 {
     request_rec *r = (request_rec *)lily_config_get(s)->data;
     ap_add_cgi_vars(r);
@@ -192,7 +192,7 @@ var get: Hash[String, Tainted[String]]
 This contains key+value pairs that were sent to the server as GET variables.
 Any pair that has a key or a value that is not valid utf-8 will not be present.
 */
-static void load_var_get(lily_state *s)
+void lily_server_var_get(lily_state *s)
 {
     apr_table_t *http_get_args;
     ap_args_to_table((request_rec *)lily_config_get(s)->data, &http_get_args);
@@ -206,7 +206,7 @@ var http_method: String
 This is the method that was used to make the request to the server.
 Common values are "GET", and "POST".
 */
-static void load_var_http_method(lily_state *s)
+void lily_server_var_http_method(lily_state *s)
 {
     request_rec *r = (request_rec *)lily_config_get(s)->data;
 
@@ -219,7 +219,7 @@ var post: Hash[String, Tainted[String]]
 This contains key+value pairs that were sent to the server as POST variables.
 Any pair that has a key or a value that is not valid utf-8 will not be present.
 */
-static void load_var_post(lily_state *s)
+void lily_server_var_post(lily_state *s)
 {
     request_rec *r = (request_rec *)lily_config_get(s)->data;
     apr_pool_t *pool;

--- a/mod_lily.c
+++ b/mod_lily.c
@@ -6,7 +6,7 @@
 
 #include "lily.h"
 
-extern const char **lily_server_table;
+extern const char *lily_server_table[];
 void *lily_server_loader(lily_state *, int);
 
 typedef struct {


### PR DESCRIPTION
Hi there, I am not sure whether the Apache bridge is still being worked on but I figured I would supply a PR anyway. Basically, while trying set up a simple example I ran into two issues:

1. The compilation using cmake and make completed without problems but apache2 refused to load the shared library due to undefined symbols:
`Cannot load /usr/lib/apache2/modules/mod_lily.so into server: /usr/lib/apache2/modules/mod_lily.so: undefined symbol: lily_server_var_get`

    The output from `nm` confirms that lily_server_var_env, lily_server_var_get, lily_server_var_http_method and lily_server_var_post are undefined. As it turns out, the methods existed but just had the wrong name (e.g. load_var_env).

2. After apache2 was able to load the module, it resulted in a Segmentation fault whenever a request came in. It was caused by an incorrect/outdated type definition for the table. It was `const char **lily_server_table` instead of `const char *lily_server_table[]`.

In the end, I was able to get a demo up and running, which is nice. Anyway, I want to thank you for publishing this project, it was a nice evening activity to debug this. :)